### PR TITLE
게시글 삭제 모달 연결 및 Post/Edit 페이지 분리

### DIFF
--- a/src/components/madal/ConfirmModal.tsx
+++ b/src/components/madal/ConfirmModal.tsx
@@ -1,4 +1,9 @@
-function ConfirmModal() {
+type ConfirmModalProps = {
+  handleDelete: () => void; // 함수 타입 정의
+  closeDeleteModal: () => void; // 함수 타입 정의
+};
+
+function ConfirmModal({ handleDelete, closeDeleteModal }: ConfirmModalProps) {
   return (
     <>
       <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
@@ -12,12 +17,14 @@ function ConfirmModal() {
           <div className="flex justify-center gap-2">
             <button
               type="submit"
+              onClick={closeDeleteModal}
               className="text-sm px-4 py-1 text-white bg-[#F28749] rounded hover:bg-[#d8743e] transition duration-300"
             >
               취소
             </button>
             <button
               type="reset"
+              onClick={handleDelete}
               className="text-sm px-4 py-1 text-[#F28749] border border-[#F28749] rounded-md hover:bg-[#f28749] hover:text-white transition duration-300"
             >
               삭제

--- a/src/pages/community/CommunityEdit.tsx
+++ b/src/pages/community/CommunityEdit.tsx
@@ -13,8 +13,9 @@ type ErrorState = {
 import { IoChevronBackOutline } from 'react-icons/io5';
 import { GoFileSymlinkFile } from 'react-icons/go';
 import { useRef, useState } from 'react';
+import ConfirmModal from '../../components/madal/ConfirmModal';
 
-function CommunityPost() {
+function CommunityEdit() {
   const [formData, setFormData] = useState<FormData>({
     category: '1',
     title: '',
@@ -132,6 +133,22 @@ function CommunityPost() {
         ...selectedFiles,
       ],
     }));
+  };
+
+  // 모달
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const handleDeleteClick = () => {
+    setShowDeleteModal(true);
+  };
+
+  const closeDeleteModal = () => {
+    setShowDeleteModal(false);
+  };
+
+  const handleDelete = async () => {
+    // 삭제 로직 (API 호출 등)
+    console.log('삭제 로직 실행');
+    closeDeleteModal(); // 삭제 후 모달 닫기
   };
 
   return (
@@ -267,20 +284,26 @@ function CommunityPost() {
         <div className="flex justify-center gap-4">
           <button
             type="submit"
-            // onClick={handleSave}
             className="text-base px-8 py-2 text-white bg-[#F28749] rounded hover:bg-[#d8743e] transition duration-300"
           >
-            등록
+            수정
           </button>
           <button
             type="reset"
+            onClick={handleDeleteClick}
             className="text-base px-8 py-2 text-[#F28749] border border-[#F28749] rounded-md hover:bg-[#f28749] hover:text-white transition duration-300"
           >
-            취소
+            삭제
           </button>
+          {showDeleteModal && (
+            <ConfirmModal
+              handleDelete={handleDelete}
+              closeDeleteModal={closeDeleteModal}
+            />
+          )}
         </div>
       </form>
     </div>
   );
 }
-export default CommunityPost;
+export default CommunityEdit;

--- a/src/pages/community/CommunityPost.tsx
+++ b/src/pages/community/CommunityPost.tsx
@@ -13,6 +13,7 @@ type ErrorState = {
 import { IoChevronBackOutline } from 'react-icons/io5';
 import { GoFileSymlinkFile } from 'react-icons/go';
 import { useRef, useState } from 'react';
+import ConfirmModal from '../../components/madal/ConfirmModal';
 
 function CommunityPost() {
   const [formData, setFormData] = useState<FormData>({
@@ -131,6 +132,22 @@ function CommunityPost() {
         ...selectedFiles,
       ],
     }));
+  };
+
+  // 모달
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const handleDeleteClick = () => {
+    setShowDeleteModal(true);
+  };
+
+  const closeDeleteModal = () => {
+    setShowDeleteModal(false);
+  };
+
+  const handleDelete = async () => {
+    // 삭제 로직 (API 호출 등)
+    console.log('삭제 로직 실행');
+    closeDeleteModal(); // 삭제 후 모달 닫기
   };
 
   return (
@@ -264,7 +281,7 @@ function CommunityPost() {
 
         {/* 등록/취소 버튼 */}
         <div className="flex justify-center gap-4">
-          <button
+          {/* <button
             type="submit"
             onClick={handleSave}
             className="text-base px-8 py-2 text-white bg-[#F28749] rounded hover:bg-[#d8743e] transition duration-300"
@@ -276,7 +293,27 @@ function CommunityPost() {
             className="text-base px-8 py-2 text-[#F28749] border border-[#F28749] rounded-md hover:bg-[#f28749] hover:text-white transition duration-300"
           >
             취소
+          </button> */}
+          <button
+            type="submit"
+            onClick={handleSave}
+            className="text-base px-8 py-2 text-white bg-[#F28749] rounded hover:bg-[#d8743e] transition duration-300"
+          >
+            수정
           </button>
+          <button
+            type="reset"
+            onClick={handleDeleteClick}
+            className="text-base px-8 py-2 text-[#F28749] border border-[#F28749] rounded-md hover:bg-[#f28749] hover:text-white transition duration-300"
+          >
+            삭제
+          </button>
+          {showDeleteModal && (
+            <ConfirmModal
+              handleDelete={handleDelete}
+              closeDeleteModal={closeDeleteModal}
+            />
+          )}
         </div>
       </form>
     </div>


### PR DESCRIPTION
## PR
- [x] 게시글 삭제 모달 연결 : edit 페이지 (#48)
- 게시글 삭제 시 사용자 확인을 위한 삭제 모달 기능 추가.
- 삭제 버튼 클릭 시 삭제 여부를 확인하는 알림 UI 및 기능 추가.
- [x] Post와 Edit 페이지 분리 (#53)
- 각 페이지의 UI와 상태 관리 로직 독립적으로 구현.