### PR TITLE
#57 feat: 카테고리 바, 커뮤니티 페이지 UI

### DIFF
--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+type Category = {
+  id: string;
+  label: string;
+};
+
+const categories: Category[] = [
+  { id: 'all', label: '전체' },
+  { id: 'balloon', label: '풍선/페이퍼아트' },
+  { id: 'gift', label: '선물포장/보자기' },
+  { id: 'wood', label: '목공/도자기/가죽' },
+  { id: 'resin', label: '레진/비즈공예' },
+  { id: 'diffuser', label: '디퓨저/캔들/석고방향제' },
+  { id: 'rattan', label: '라탄/마크라메' },
+  { id: 'flower', label: '플라워' },
+  { id: 'total', label: '토탈공예' },
+];
+
+const Category: React.FC = () => {
+  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+
+  const handleCategoryClick = (id: string) => {
+    setSelectedCategory(id);
+  };
+
+  return (
+    <div className="w-[1300px] h-[80px] flex items-center justify-between border-t-2 border-b-2 border-[#F0F0F0] bg-[#FFF] mx-auto">
+      {categories.map((category) => (
+        <button
+          key={category.id}
+          onClick={() => handleCategoryClick(category.id)}
+          className={`text-[20px] font-medium leading-normal tracking-[1.2px] px-4 focus:outline-none transition-colors duration-200
+            ${
+              selectedCategory === category.id
+                ? 'text-[#F28749] border-b-2 border-[#F28749] pb-1'
+                : 'text-[#000]'
+            }
+          `}
+        >
+          {category.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default Category;

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -1,5 +1,117 @@
-const Community = () => {
-  return <h1> Community</h1>;
+import React, { useState } from 'react';
+
+type Post = {
+  category: string;
+  title: string;
+  author: string;
+  date: string;
+  views: number;
+};
+
+// 더미 데이터 생성 함수
+const generateDummyPosts = (count: number): Post[] => {
+  const categories = [
+    '레진/비즈공예',
+    '목공/도자기/가죽',
+    '플라워',
+    '디퓨저/캔들/석고방향제',
+    '라탄/마크라메',
+  ];
+  const authors = ['author1', 'author2', 'author3', 'author4', 'author5'];
+  const titles = [
+    '비즈의 종류는 무엇이 있나요?',
+    '가죽 공예의 기초',
+    '플라워 데코레이션 팁',
+    '캔들 제작을 위한 팁',
+    '마크라메 기초 배우기',
+  ];
+
+  const dummyPosts: Post[] = [];
+  for (let i = 0; i < count; i++) {
+    dummyPosts.push({
+      category: categories[i % categories.length],
+      title: titles[i % titles.length],
+      author: authors[i % authors.length],
+      date: `2024.12.${16 - (i % 10)}`,
+      views: Math.floor(Math.random() * 1000),
+    });
+  }
+  return dummyPosts;
+};
+
+const allPosts: Post[] = generateDummyPosts(50); // 50개의 더미 데이터 생성
+
+const Community: React.FC = () => {
+  const [searchQuery, setSearchQuery] = useState<string>(''); // 검색어 상태
+  const [visibleCount, setVisibleCount] = useState<number>(10); // 한 번에 표시할 게시글 수
+
+  // 검색어에 따라 게시글 필터링
+  const filteredPosts = allPosts.filter((post) =>
+    post.title.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  // 현재 표시할 게시글
+  const visiblePosts = filteredPosts.slice(0, visibleCount);
+
+  // more 버튼 클릭 핸들러
+  const handleMoreClick = () => {
+    setVisibleCount((prevCount) => prevCount + 10); // 10개씩 더 보기
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center bg-[#FFFBEF]">
+      <div className="w-[81.25rem] px-4 mt-[6.25rem]">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-[#F28749] text-2xl font-bold">커뮤니티</h1>
+          <input
+            type="text"
+            placeholder="검색어를 입력하세요"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="border rounded-lg px-4 py-2 w-[20rem] focus:outline-none focus:ring-2 focus:ring-[#F28749]"
+          />
+        </div>
+
+        <div className="bg-white shadow-md rounded-lg p-4">
+          {visiblePosts.length > 0 ? (
+            visiblePosts.map((post, index) => (
+              <div
+                key={index}
+                className="flex items-center justify-between border-b last:border-b-0 py-4 text-[#0F0F0F]"
+              >
+                <div className="flex items-center">
+                  <span className="text-[#F28749] font-medium mr-4">
+                    [{post.category}]
+                  </span>
+                  <span className="text-lg font-bold">{post.title}</span>
+                </div>
+                <div className="flex items-center text-sm text-gray-500">
+                  <span className="mr-4">{post.author}</span>
+                  <span className="mr-4">{post.date}</span>
+                  <span>{post.views} 조회</span>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-center text-gray-500 py-4">
+              검색 결과가 없습니다.
+            </div>
+          )}
+        </div>
+
+        {visiblePosts.length < filteredPosts.length && (
+          <div className="flex justify-center mt-8">
+            <button
+              onClick={handleMoreClick}
+              className="text-[#F28749] font-bold border border-[#F28749] rounded-lg px-6 py-2 hover:bg-[#F28749] hover:text-white transition duration-300"
+            >
+              more
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default Community;


### PR DESCRIPTION
커뮤니티 페이지 UI 작성 후

페이지 안에 필요한 로직 정리

더미데이터에 대한 데이터 API 불러오기
검색 로직 - 서치쿼리로 상태추가 검색어 관리 / input에서 onChange
이벤트로 상태 업데이트
filterPosts --> posts 배열에서 서치쿼리를 포함한 게시물만
추가적으로 필요한 로직

카테고리바 UI 컴포넌트 새로운 layout 파일 만들어서 연결(커뮤니티, 상세 페이지만 연결)
검색에 대한 로직을 디바운스를 통한 로직으로 수정
현재 페이지 페이지네이션을 MORE 페이지 눌렀을 시 추가 나열이 아닌 10개의 요소씩 추가적인 페이지네이션으로 수정