### PR TITLE
#75 feat: 커뮤니티 페이지 페이지네이션 UI 수정 및 카테고리 바 컴포넌트 CategoryLayout으로 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,14 +11,17 @@ import LogIn from './pages/login/LogIn';
 import SignUp from './pages/signup/SignUp';
 import CommunityPost from './pages/community/CommunityPost';
 import Layout from './layout/Layout';
+import CategoryLayout from './layout/CategoryLayout';
 
 const App = () => {
   return (
     <Routes>
       <Route element={<Layout />}>
         <Route path="/" element={<Main />} />
-        <Route path="/community" element={<Community />} />
-        <Route path="/communitydetail" element={<CommunityDetail />} />
+        <Route element={<CategoryLayout />}>
+          <Route path="/community" element={<Community />} />
+          <Route path="/communitydetail" element={<CommunityDetail />} />
+        </Route>
         <Route
           path="/communitypost/:id"
           element={<CommunityPost type={'edit'} />}

--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -1,48 +1,79 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import { IoMenuOutline, IoCloseOutline } from 'react-icons/io5';
 
-type Category = {
-  id: string;
-  label: string;
-};
+function Category() {
+  const categories = [
+    { id: 'all', label: '전체' },
+    { id: 'balloon', label: '풍선/페이퍼아트' },
+    { id: 'gift', label: '선물포장/보자기' },
+    { id: 'wood', label: '목공/도자기/가죽' },
+    { id: 'resin', label: '레진/비즈공예' },
+    { id: 'diffuser', label: '디퓨저/캔들/석고방향제' },
+    { id: 'rattan', label: '라탄/마크라메' },
+    { id: 'flower', label: '플라워' },
+    { id: 'total', label: '토탈공예' },
+  ];
 
-const categories: Category[] = [
-  { id: 'all', label: '전체' },
-  { id: 'balloon', label: '풍선/페이퍼아트' },
-  { id: 'gift', label: '선물포장/보자기' },
-  { id: 'wood', label: '목공/도자기/가죽' },
-  { id: 'resin', label: '레진/비즈공예' },
-  { id: 'diffuser', label: '디퓨저/캔들/석고방향제' },
-  { id: 'rattan', label: '라탄/마크라메' },
-  { id: 'flower', label: '플라워' },
-  { id: 'total', label: '토탈공예' },
-];
-
-const Category: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
 
   const handleCategoryClick = (id: string) => {
     setSelectedCategory(id);
+    setIsMenuOpen(false); // 카테고리 선택 시 메뉴 닫기
   };
 
   return (
-    <div className="w-[1300px] h-[80px] flex items-center justify-between border-t-2 border-b-2 border-[#F0F0F0] bg-[#FFF] mx-auto">
-      {categories.map((category) => (
+    <div className="w-full bg-white border-t-2 border-b-2 border-[#F0F0F0]">
+      {/* 데스크탑 레이아웃 */}
+      <div className="hidden md:flex w-[1300px] h-[80px] items-center justify-between mx-auto">
+        {categories.map((category) => (
+          <button
+            key={category.id}
+            onClick={() => handleCategoryClick(category.id)}
+            className={`text-[14px] md:text-[16px] lg:text-[18px] font-medium leading-normal tracking-[1px] px-4 focus:outline-none transition-colors duration-200
+              ${
+                selectedCategory === category.id
+                  ? 'text-[#F28749] border-b-2 border-[#F28749] pb-1'
+                  : 'text-[#000]'
+              }
+            `}
+          >
+            {category.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 모바일 레이아웃 */}
+      <div className="md:hidden px-4 py-2 flex items-center justify-between">
+        <span className="text-[14px] font-bold text-[#F28749]">카테고리</span>
         <button
-          key={category.id}
-          onClick={() => handleCategoryClick(category.id)}
-          className={`text-[20px] font-medium leading-normal tracking-[1.2px] px-4 focus:outline-none transition-colors duration-200
-            ${
-              selectedCategory === category.id
-                ? 'text-[#F28749] border-b-2 border-[#F28749] pb-1'
-                : 'text-[#000]'
-            }
-          `}
+          onClick={() => setIsMenuOpen(!isMenuOpen)}
+          className="text-[#F28749] text-2xl focus:outline-none"
         >
-          {category.label}
+          {isMenuOpen ? <IoCloseOutline /> : <IoMenuOutline />}
         </button>
-      ))}
+      </div>
+      {isMenuOpen && (
+        <div className="md:hidden bg-white shadow-md rounded-lg mx-4 mt-2">
+          {categories.map((category) => (
+            <button
+              key={category.id}
+              onClick={() => handleCategoryClick(category.id)}
+              className={`block w-full text-left px-4 py-2 text-[14px] font-medium leading-normal tracking-[1px] focus:outline-none transition-colors duration-200
+                ${
+                  selectedCategory === category.id
+                    ? 'text-[#F28749] bg-[#FFF4E8]'
+                    : 'text-[#000]'
+                }
+              `}
+            >
+              {category.label}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
-};
+}
 
 export default Category;

--- a/src/layout/CategoryLayout.tsx
+++ b/src/layout/CategoryLayout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router-dom';
+import Category from '../components/category/Category';
+export default function CategoryLayout() {
+  return (
+    <div>
+      <Category />
+      <Outlet />
+    </div>
+  );
+}

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -24,6 +24,16 @@ const generateDummyPosts = (count: number): Post[] => {
     '플라워 데코레이션 팁',
     '캔들 제작을 위한 팁',
     '마크라메 기초 배우기',
+    '목공 작업의 안전 수칙',
+    '도자기 굽기 전 주의사항',
+    '선물 포장 아이디어 10가지',
+    '핸드메이드 디퓨저 만들기',
+    '캔들 향 선택 방법',
+    '비즈 공예를 위한 도구 소개',
+    '라탄 가구 제작 과정',
+    '마크라메 벽 장식 만들기',
+    '초보자를 위한 플라워 디자인',
+    '석고 방향제의 장단점',
   ];
 
   const dummyPosts: Post[] = [];
@@ -39,39 +49,83 @@ const generateDummyPosts = (count: number): Post[] => {
   return dummyPosts;
 };
 
-const allPosts: Post[] = generateDummyPosts(50); // 50개의 더미 데이터 생성
+const allPosts: Post[] = generateDummyPosts(100); // 100개의 더미 데이터 생성
 
 const Community: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState<string>(''); // 검색어 상태
-  const [visibleCount, setVisibleCount] = useState<number>(10); // 한 번에 표시할 게시글 수
+  const [currentPage, setCurrentPage] = useState<number>(1); // 현재 페이지 상태
+  const [currentPageGroup, setCurrentPageGroup] = useState<number>(0); // 현재 페이지 그룹
+  const postsPerPage = 10; // 페이지당 표시할 게시글 수
+  const pagesPerGroup = 5; // 한 번에 표시할 페이지 수
 
   // 검색어에 따라 게시글 필터링
-  const filteredPosts = allPosts.filter((post) =>
-    post.title.toLowerCase().includes(searchQuery.toLowerCase())
+  const filteredPosts = allPosts.filter((post) => {
+    const query = searchQuery.toLowerCase();
+    return (
+      post.title.toLowerCase().includes(query) ||
+      post.category.toLowerCase().includes(query) ||
+      post.author.toLowerCase().includes(query)
+    );
+  });
+
+  // 현재 페이지에 표시할 게시글
+  const startIndex = (currentPage - 1) * postsPerPage;
+  const visiblePosts = filteredPosts.slice(
+    startIndex,
+    startIndex + postsPerPage
   );
 
-  // 현재 표시할 게시글
-  const visiblePosts = filteredPosts.slice(0, visibleCount);
+  // 총 페이지 수 계산
+  const totalPages = Math.ceil(filteredPosts.length / postsPerPage);
 
-  // more 버튼 클릭 핸들러
-  const handleMoreClick = () => {
-    setVisibleCount((prevCount) => prevCount + 10); // 10개씩 더 보기
+  // 현재 페이지 그룹에 표시할 페이지 번호 계산
+  const getPageNumbers = () => {
+    const startPage = currentPageGroup * pagesPerGroup + 1;
+    const endPage = Math.min(startPage + pagesPerGroup - 1, totalPages);
+    return Array.from(
+      { length: endPage - startPage + 1 },
+      (_, i) => startPage + i
+    );
+  };
+
+  // 페이지 이동 핸들러
+  const handlePageClick = (pageNumber: number) => {
+    setCurrentPage(pageNumber);
+  };
+
+  // 다음 그룹 핸들러
+  const handleNextGroup = () => {
+    if ((currentPageGroup + 1) * pagesPerGroup < totalPages) {
+      setCurrentPageGroup((prev) => prev + 1);
+    }
+  };
+
+  // 이전 그룹 핸들러
+  const handlePrevGroup = () => {
+    if (currentPageGroup > 0) {
+      setCurrentPageGroup((prev) => prev - 1);
+    }
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center bg-[#FFFBEF]">
-      <div className="w-[81.25rem] px-4 mt-[6.25rem]">
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-[#F28749] text-2xl font-bold">커뮤니티</h1>
+    <div className="min-h-screen flex flex-col items-center bg-white">
+      {/* 검색 및 게시글 섹션 */}
+      <div className="w-full max-w-5xl px-4 mt-4 md:mt-6">
+        {/* 검색 필드 */}
+        <div className="flex flex-col md:flex-row justify-between items-center mb-4">
+          <h1 className="text-[#F28749] text-lg md:text-2xl font-bold mb-2 md:mb-0">
+            커뮤니티
+          </h1>
           <input
             type="text"
             placeholder="검색어를 입력하세요"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="border rounded-lg px-4 py-2 w-[20rem] focus:outline-none focus:ring-2 focus:ring-[#F28749]"
+            className="w-full md:w-[20rem] border rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#F28749]"
           />
         </div>
 
+        {/* 게시글 리스트 */}
         <div className="bg-white shadow-md rounded-lg p-4">
           {visiblePosts.length > 0 ? (
             visiblePosts.map((post, index) => (
@@ -83,11 +137,13 @@ const Community: React.FC = () => {
                   <span className="text-[#F28749] font-medium mr-4">
                     [{post.category}]
                   </span>
-                  <span className="text-lg font-bold">{post.title}</span>
+                  <span className="text-sm md:text-base font-bold">
+                    {post.title}
+                  </span>
                 </div>
-                <div className="flex items-center text-sm text-gray-500">
-                  <span className="mr-4">{post.author}</span>
-                  <span className="mr-4">{post.date}</span>
+                <div className="flex items-center text-xs md:text-sm text-gray-500">
+                  <span className="mr-2">{post.author}</span>
+                  <span className="mr-2">{post.date}</span>
                   <span>{post.views} 조회</span>
                 </div>
               </div>
@@ -99,16 +155,38 @@ const Community: React.FC = () => {
           )}
         </div>
 
-        {visiblePosts.length < filteredPosts.length && (
-          <div className="flex justify-center mt-8">
-            <button
-              onClick={handleMoreClick}
-              className="text-[#F28749] font-bold border border-[#F28749] rounded-lg px-6 py-2 hover:bg-[#F28749] hover:text-white transition duration-300"
+        {/* 페이지네이션 */}
+        <div className="flex justify-center mt-4 gap-2">
+          {currentPageGroup > 0 && (
+            <span
+              onClick={handlePrevGroup}
+              className="cursor-pointer text-sm md:text-base text-gray-500 hover:text-[#F28749]"
             >
-              more
-            </button>
-          </div>
-        )}
+              이전
+            </span>
+          )}
+          {getPageNumbers().map((page) => (
+            <span
+              key={page}
+              onClick={() => handlePageClick(page)}
+              className={`cursor-pointer px-2 text-sm md:text-base ${
+                currentPage === page
+                  ? 'text-[#F28749] font-bold underline'
+                  : 'text-gray-500 hover:text-[#F28749]'
+              }`}
+            >
+              {page}
+            </span>
+          ))}
+          {(currentPageGroup + 1) * pagesPerGroup < totalPages && (
+            <span
+              onClick={handleNextGroup}
+              className="cursor-pointer text-sm md:text-base text-gray-500 hover:text-[#F28749]"
+            >
+              더보기
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
API 연결 로직 구현 전, 필요한 마지막 UI 구성 및 Category레이아웃 파일 생성으로
카테고리 바 컴포넌트 Category / CategoryDetail 페이지에 나타낼 수 있도록 작성

현재 코드 수정사항)

기존 페이지네이션 MORE 버튼을 통해 더 많은 게시글 표시
--> 각 페이지 당 10개의 게시글이 표시되도록, 1 2 3 4 5 더보기 텍스트를 통해 추가적인 페이지도 볼 수 있도록 구성
CategoryLayout 파일을 만들고, App.tsx 파일에 경로 설정해서 두개의 페이지에 Category 컴포넌트가 포함될 수 있도록 수정
다음 수정사항)
카테고리 컴포넌트 모바일 환경 사이즈 기준으로 햄버거바 메뉴형식으로 반응형 수정, 다른 요소들도 반영

현재 axiosinstance 파일을 통해 API 명세서의 3.2 게시글 목록 조회 파트에 대한 연결 로직 코드 수정
But, 추가적으로 필요한 좋아요에 대한 부분 명세 작성자에게 추가 요청하기
검색 로직또한 현재 받아올 데이터들을 통해 겸색 결과를 보여줘야하기에 서치 파라미터와 디바운스를 통해 세팅하기
카테고리 바에서 각 공예 카테고리를 클릭했을때 각 카테고리 페이지고 이동할 수 있도록 각 페이지의 URL도 다르게 설정
이후 추가적인 수정사항은 공유하며 진행할 예정
