### PR TITLE
 폼 데이터 타입 정의 및 초기 상태 분리

### DIFF
--- a/src/pages/community/CommunityPost.tsx
+++ b/src/pages/community/CommunityPost.tsx
@@ -1,40 +1,19 @@
-type FormData = {
-  category: string;
-  title: string;
-  content: string;
-  images: File[] | null; // image는 null 또는 File 타입
-};
-
-type ErrorState = {
-  category: string | null;
-  image: string | null | undefined;
-};
-
 import { IoChevronBackOutline } from 'react-icons/io5';
 import { GoFileSymlinkFile } from 'react-icons/go';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import axiosAuthInstance from '../../api/axiosAuthInstance';
 import ConfirmModal from '../../components/modal/ConfirmModal';
+import { initFormData, initError, ERROR_MESSAGES } from './const';
+import type { FormData, FormType, ErrorState } from './type';
 
-function CommunityPost({ type }: { type: 'post' | 'edit' }) {
-  const [formData, setFormData] = useState<FormData>({
-    category: '1',
-    title: '',
-    content: '',
-    images: [],
-  });
+type Props = {
+  type: FormType;
+};
 
-  const ERROR_MESSAGES = {
-    categoryRequired: '카테고리를 선택해야 합니다.',
-    maxFileLimit: '최대 3개의 파일만 업로드 가능합니다.',
-    imageFileOnly: '이미지 파일만 업로드 가능합니다.',
-  };
-
-  const [error, setError] = useState<ErrorState>({
-    category: null,
-    image: null,
-  });
+function CommunityPost({ type }: Props) {
+  const [formData, setFormData] = useState<FormData>(initFormData);
+  const [error, setError] = useState<ErrorState>(initError);
 
   const { id } = useParams();
   const navigate = useNavigate();

--- a/src/pages/community/const.ts
+++ b/src/pages/community/const.ts
@@ -1,0 +1,19 @@
+import type { FormData, ErrorState } from './type';
+
+export const initFormData: FormData = {
+  category: '1',
+  title: '',
+  content: '',
+  images: [],
+};
+
+export const ERROR_MESSAGES = {
+  categoryRequired: '카테고리를 선택해야 합니다.',
+  maxFileLimit: '최대 3개의 파일만 업로드 가능합니다.',
+  imageFileOnly: '이미지 파일만 업로드 가능합니다.',
+};
+
+export const initError: ErrorState = {
+  category: null,
+  image: null,
+};

--- a/src/pages/community/type.ts
+++ b/src/pages/community/type.ts
@@ -1,0 +1,13 @@
+export type FormType = 'post' | 'edit';
+
+export type FormData = {
+  category: string;
+  title: string;
+  content: string;
+  images: File[] | null; // image는 null 또는 File 타입
+};
+
+export type ErrorState = {
+  category: string | null;
+  image: string | null | undefined;
+};


### PR DESCRIPTION
## PR
- [x] FormData와 ErrorState 타입 정의를 별도의 파일로 분리 #110 
- [x] 폼의 초기 값 initFormData, initError, ERROR_MESSAGES 별도 파일에서 관리하도록 수정 #110  