### PR TITLE
반응형 디자인을 적용 및 뒤로가기 버튼 추가 

### DIFF
--- a/src/pages/community/CommunityPost.tsx
+++ b/src/pages/community/CommunityPost.tsx
@@ -32,6 +32,7 @@ function CommunityPost({ type }: Props) {
     handleDeleteClick,
     closeDeleteModal,
     handleDelete,
+    handleBackButtonClick,
   } = useCommunityPostHook({
     fileInputRef,
     formData,
@@ -47,7 +48,10 @@ function CommunityPost({ type }: Props) {
 
   return (
     <div className="mx-auto min-h-screen py-20 px-4 bg-[#FFFBEF] max-sm:h-auto">
-      <div className="flex items-center mb-8 text-2xl font-bold text-gray-600 cursor-pointer ">
+      <div
+        onClick={handleBackButtonClick}
+        className="flex items-center mb-8 text-2xl font-bold text-gray-600 cursor-pointer "
+      >
         <IoChevronBackOutline /> 게시판
       </div>
 

--- a/src/pages/community/CommunityPost.tsx
+++ b/src/pages/community/CommunityPost.tsx
@@ -44,11 +44,10 @@ function CommunityPost({ type }: Props) {
     showDeleteModal,
     setShowDeleteModal,
   });
-  // console.log(formData);
 
   return (
     <div className="mx-auto min-h-screen py-20 px-4 bg-[#FFFBEF] max-sm:h-auto">
-      <div className="flex items-center mb-8">
+      <div className="flex items-center mb-8 text-2xl font-bold text-gray-600 cursor-pointer ">
         <IoChevronBackOutline /> 게시판
       </div>
 
@@ -117,11 +116,11 @@ function CommunityPost({ type }: Props) {
         </div>
 
         {/* 이미지 첨부 */}
-        <div className="flex justify-between p-2 mb-4 border rounded focus:outline-none focus:ring-2 focus:ring-[#F28749]">
-          <div className="flex flex-col items-start justify-center">
+        <div className="flex justify-between p-2 mb-4 border rounded focus:outline-none focus:ring-2 focus:ring-[#F28749] w-full max-w-4xl mx-auto">
+          <div className="flex flex-col items-start justify-center w-full max-w-[75%]">
             {formData.images?.length ? (
               formData.images.map((file, index) => (
-                <div key={index} className="text-[#a9a9a9]">
+                <div key={index} className="truncate w-full text-[#a9a9a9] ">
                   {`${index + 1}. ` +
                     (file instanceof File ? file.name : file.image_url)}
                 </div>
@@ -135,7 +134,9 @@ function CommunityPost({ type }: Props) {
               onClick={handleButtonClick}
               className=" justify-end p-2 border rounded focus:outline-none focus:ring-2 focus:ring-[#F28749] cursor-pointer"
             >
-              이미지첨부
+              {/* 화면 크기에 따라 버튼 텍스트 변경 */}
+              <span className="hidden sm:inline">이미지첨부</span>
+              <span className="inline sm:hidden">사진첨부</span>
             </button>
             <input
               type="file"

--- a/src/pages/community/usePostHook.tsx
+++ b/src/pages/community/usePostHook.tsx
@@ -224,6 +224,10 @@ function useCommunityPostHook({
     }
   };
 
+  const handleBackButtonClick = () => {
+    navigate('/community');
+  };
+
   return {
     handleChange,
     handleSave,
@@ -233,6 +237,7 @@ function useCommunityPostHook({
     handleDeleteClick,
     closeDeleteModal,
     handleDelete,
+    handleBackButtonClick,
   };
 }
 


### PR DESCRIPTION
## PR
- [x] <게시판 클릭 시 `/community` 페이지로 이동하도록 `navigate` 함수를 활용하여 기능 구현.
- [x] 반응형을 고려하여 이미지 정보 텍스트를 ... 줄임 표시로 변경 및 이미지 첨부 버튼과 함께 부모 컨테이너의 크기를 벗어나지 않도록 수정
- [x] 화면 크기에 따라 버튼 텍스트 변경. 이미지첨부->사진첨부
폴더 누락으로 재 수정 